### PR TITLE
Bumping up Dividend API (v2 -> v3)

### DIFF
--- a/examples/dividends.rs
+++ b/examples/dividends.rs
@@ -29,7 +29,7 @@ async fn main() {
                 .results
                 .iter()
                 .filter(|&x| {
-                    NaiveDate::parse_from_str(&x.ex_date, "%Y-%m-%d").unwrap()
+                    NaiveDate::parse_from_str(&x.ex_dividend_date, "%Y-%m-%d").unwrap()
                         > one_year_ago.naive_local()
                 })
                 .collect::<Vec<_>>();
@@ -47,7 +47,7 @@ async fn main() {
                 }
 
                 let close = previous_close_res.results.first().unwrap().c;
-                let sum: f64 = res.iter().map(|d| d.amount).sum();
+                let sum: f64 = res.iter().map(|d| d.cash_amount).sum();
 
                 println!("Yield for {} is {:.2}% [previous close = {}, sum of last {} dividends = {:.2}]",
                     ticker,

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -206,13 +206,13 @@ impl RESTClient {
     }
 
     /// Get a list of historical dividends for a stock using the
-    /// [/v2/reference/dividends/{stocks_ticker}](https://polygon.io/docs/get_v2_reference_dividends__stocksTicker__anchor) API.
+    /// [/v3/reference/dividends/{stocks_ticker}](https://polygon.io/docs/get_v3_reference_dividends__stocksTicker__anchor) API.
     pub async fn reference_stock_dividends(
         &self,
         stocks_ticker: &str,
         query_params: &HashMap<&str, &str>,
     ) -> Result<ReferenceStockDividendsResponse, reqwest::Error> {
-        let uri = format!("/v2/reference/dividends/{}", stocks_ticker);
+        let uri = format!("/v3/reference/dividends?ticker={}", stocks_ticker);
         self.send_request::<ReferenceStockDividendsResponse>(&uri, query_params)
             .await
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -237,29 +237,30 @@ pub struct ReferenceStockSplitsResponseV2 {
 pub type ReferenceStockSplitsResponse = ReferenceStockSplitsResponseV2;
 
 //
-// v2/reference/dividends/{stocksTicker}
+// v3/reference/dividends/
 //
 
 #[derive(Clone, Deserialize, Debug)]
-pub struct ReferenceStockDividendsResultV2 {
-    pub ticker: String,
-    #[serde(rename = "exDate")]
-    pub ex_date: String,
-    #[serde(rename = "paymentDate")]
-    pub payment_date: String,
-    #[serde(rename = "recordDate")]
+pub struct ReferenceStockDividendsResultV3 {
+    pub cash_amount: f64,
+    pub currency: String,
+    pub declaration_date: String,
+    pub dividend_type: DividendType,
+    pub ex_dividend_date: String,
+    pub frequency: u32,
+    pub pay_date: String,
     pub record_date: String,
-    pub amount: f64,
+    pub ticker: String,
 }
 
 #[derive(Clone, Deserialize, Debug)]
-pub struct ReferenceStockDividendsResponseV2 {
+pub struct ReferenceStockDividendsResponseV3 {
+    pub next_url: Option<String>,
+    pub results: Vec<ReferenceStockDividendsResultV3>,
     pub status: String,
-    pub count: u32,
-    pub results: Vec<ReferenceStockDividendsResultV2>,
 }
 
-pub type ReferenceStockDividendsResponse = ReferenceStockDividendsResponseV2;
+pub type ReferenceStockDividendsResponse = ReferenceStockDividendsResponseV3;
 
 //
 // v2/reference/financials/{stocksTicker}
@@ -862,6 +863,25 @@ pub type StockEquitiesExchangesResponse = Vec<StockEquitiesExchangeV1>;
 pub enum TickType {
     Trades,
     Quotes,
+}
+
+#[derive(Clone, Deserialize, Debug)]
+pub enum DividendType {
+    CD, // Consistent dividends paid on schedule
+    SC, // Special cash dividends (not to be expected to be consistenly paid)
+    LT, // Long-term capital gain distributions
+    ST, // Short-term capital gain distributions
+}
+
+impl fmt::Display for DividendType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            DividendType::CD => write!(f, "CD"),
+            DividendType::SC => write!(f, "SC"),
+            DividendType::LT => write!(f, "LT"),
+            DividendType::ST => write!(f, "ST"),
+        }
+    }
 }
 
 impl fmt::Display for TickType {


### PR DESCRIPTION
Hi @epakskape  @mattsre ,

Polygon.io  has updated its [API](https://polygon.io/docs/stocks/get_v3_reference_dividends) for getting historical dividend data. Old API still works (endpoint is available) , but it seems v2 returns invalid data. Doc of V2 is not-existing (Error 404) so I assumed v2 is outdated. 

This PR is replacing dividend v2 with dividend v3.

Thanks very much for working on this crate.

